### PR TITLE
Foldermd5 auto regedit-reinventing the wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.crx
 *.bak
 *.lnk
+*.log
+test*.*
 lib/*
 !lib/FALC
 

--- a/foldermd5.pl
+++ b/foldermd5.pl
@@ -850,7 +850,7 @@ state $pauseonexit = 0;
 }
 
 # Installs the application into the Windows registry so it appears in the right-click context menus
-# The current locaiton of the script is used for the registry entries. The current location should
+# The current location of the script is used for the registry entries. The current location should
 # contain the 'lib' folder with the user defined Perl modules.
 # Execution of this function will require Administrator privileges.
 use Config;
@@ -881,70 +881,66 @@ my $cmdrval;
    
    $delim = $Registry->Delimiter("/");
 
-   # Should be possible to run the perl command without going via a cmd script
-   #$cmdval  = "cmd /c \"%\"" . $apppath . "%\" -l -p %\"%1%\"\"";
-   #$cmdxval = "cmd /c \"%\"" . $apppath . "%\" -r -l -p %\"%1%\"\"";
-   #$cmdrval = "cmd /c \"%\"" . $apppath . "%\"-c -l -p %\"%1%\"\"";
    $cmdval  = $plpath . " \"" . $apppath .    "\" -l -p \"%1\"";
    $cmdxval = $plpath . " \"" . $apppath . "\" -r -l -p \"%1\"";
    $cmdrval = $plpath . " \"" . $apppath . "\" -c -l -p \"%1\"";
-# [HKEY_CLASSES_ROOT\Directory\shell\FolderMD5\command]
-# @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
+
+   # [HKEY_CLASSES_ROOT\Directory\shell\FolderMD5\command]
+   # @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
    $shellkey = delimitkey("Classes","Directory");
    $appkeyname = "FolderMD5";
-   addShellCommand($shellkey, $appkeyname, $cmdval, 0);  # $rootkeyname, $appname, $cmd, $ext
+   addShellCommand($shellkey, $appkeyname, $cmdval, 0);
 
-# [HKEY_CLASSES_ROOT\Directory\shell\FolderMD5 Recalculate] "Extended"=""
-# [HKEY_CLASSES_ROOT\Directory\shell\FolderMD5 Recalculate\command] @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -r -l -p %\"%1%\"\""
+   # [HKEY_CLASSES_ROOT\Directory\shell\FolderMD5 Recalculate] "Extended"=""
+   # [HKEY_CLASSES_ROOT\Directory\shell\FolderMD5 Recalculate\command] 
+   # @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -r -l -p %\"%1%\"\""
    $appkeyname = "FolderMD5 Recalculate";
-   addShellCommand($shellkey, $appkeyname, $cmdxval, 1);  # $rootkeyname, $appname, $cmd, $ext
-   
+   addShellCommand($shellkey, $appkeyname, $cmdxval, 1);
 
-# [HKEY_CLASSES_ROOT\Drive\shell\FolderMD5\command]
-# @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %1\""
+   # [HKEY_CLASSES_ROOT\Drive\shell\FolderMD5\command]
+   # @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %1\""
    $shellkey = delimitkey("Classes", "Drive");
    $appkeyname = "FolderMD5";
-   addShellCommand($shellkey, $appkeyname, $cmdval, 0);  # $rootkeyname, $appname, $cmd, $ext
+   addShellCommand($shellkey, $appkeyname, $cmdval, 0);
 
-# 
-# [HKEY_CLASSES_ROOT\Drive\shell\FolderMD5 Recalculate]  "Extended"=""
-# [HKEY_CLASSES_ROOT\Drive\shell\FolderMD5 Recalculate\command] @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -r -l -p %1\""
+   # [HKEY_CLASSES_ROOT\Drive\shell\FolderMD5 Recalculate]  "Extended"=""
+   # [HKEY_CLASSES_ROOT\Drive\shell\FolderMD5 Recalculate\command] 
+   # @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -r -l -p %1\""
    $appkeyname = "FolderMD5 Recalculate";
-   addShellCommand($shellkey, $appkeyname, $cmdxval, 1);  # $rootkeyname, $appname, $cmd, $ext
-
-
-# [HKEY_CLASSES_ROOT\DVD\shell\FolderMD5\command]
-# @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -c -l -p %\"%1%\"\""
-
+   addShellCommand($shellkey, $appkeyname, $cmdxval, 1);
    
+   # [HKEY_CLASSES_ROOT\DVD\shell\FolderMD5\command]
+   # @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -c -l -p %\"%1%\"\""
    $shellkey = delimitkey("Classes", "DVD");
    $appkeyname = "FolderMD5";
-   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);  # $rootkeyname, $appname, $cmd, $ext
+   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);
 
-# [HKEY_CLASSES_ROOT\WMP11.AssocFile.M4A\shell\FolderMD5 Update\command] @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
+   # [HKEY_CLASSES_ROOT\WMP11.AssocFile.M4A\shell\FolderMD5 Update\command]
+   # @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
    $shellkey = delimitkey("Classes", "WMP11.AssocFile.M4A");
    $appkeyname = "FolderMD5 Update";
-   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);  # $rootkeyname, $appname, $cmd, $ext
-
+   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);
  
-# [HKEY_CLASSES_ROOT\iTunes.m4v\shell\FolderMD5 Update\command] @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
+   # [HKEY_CLASSES_ROOT\iTunes.m4v\shell\FolderMD5 Update\command]
+   # @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
    $shellkey = delimitkey("Classes", "iTunes.m4v");
-   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);  # $rootkeyname, $appname, $cmd, $ext
-
+   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);
  
-# [HKEY_CLASSES_ROOT\WMP11.AssocFile.MP3\shell\FolderMD5 Update\command] @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
+   # [HKEY_CLASSES_ROOT\WMP11.AssocFile.MP3\shell\FolderMD5 Update\command]
+   # @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
    $shellkey = delimitkey("Classes", "WMP11.AssocFile.MP3");
-   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);  # $rootkeyname, $appname, $cmd, $ext
+   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);
 
- 
-# [HKEY_CLASSES_ROOT\WMP.FlacFile\shell\FolderMD5 Update\command] @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
+   # [HKEY_CLASSES_ROOT\WMP.FlacFile\shell\FolderMD5 Update\command]
+   # @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
    $shellkey = delimitkey("Classes", "WMP11.FlacFile");
-   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);  # $rootkeyname, $appname, $cmd, $ext
+   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);
 
 
-# [HKEY_CLASSES_ROOT\WMP11.AssocFile.MP4\shell\FolderMD5 Update\command] @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
+   # [HKEY_CLASSES_ROOT\WMP11.AssocFile.MP4\shell\FolderMD5 Update\command]
+   # @="cmd /c \"%\"C:\\Program Files\\Utils\\foldermd5.cmd%\" -l -p %\"%1%\"\""
    $shellkey = delimitkey("Classes", "WMP11.AssocFile.MP4");
-   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);  # $rootkeyname, $appname, $cmd, $ext
+   addShellCommand($shellkey, $appkeyname, $cmdrval, 0);
 }
 
 sub addShellCommand # $rootkeyname, $appname, $cmd, $ext
@@ -969,29 +965,43 @@ my $result;
    } 
  
    my $appkey = $shellkey->Open($appname . $delim);
-   if(defined($appkey))
+   if( ! defined($appkey))
    {
-      $LOG->info($appkey->Path ." key already exists: deleting\n");
-      deleteReg($shellkey, $appname . $delim);
+      $LOG->info($appname ." key does not exist: creating\n");
+      $appkey = $shellkey->CreateKey($appname);
+      # deleteReg($shellkey, $appname . $delim);
    }
 
-   $appkey = $shellkey->CreateKey($appname);
+   # $appkey = $shellkey->CreateKey($appname);
    if(! defined($appkey))
    {
-      $LOG->info("Failed to create key: $appname \n");
+      $LOG->info("Failed to open/create key: $appname \n");
       die(1);
    }
-   my $cmdkey = $appkey->CreateKey("command");
+   
+   my $cmdkey = $appkey->Open("command" . $delim);
+   
+   
    if(! defined($cmdkey))
    {
-      $LOG->info("Failed to create key: $appname/command \n");
-
-      die(1);
+      $cmdkey = $appkey->CreateKey("command");
+      if(! defined($cmdkey) )
+      {
+         $LOG->info("Failed to create/open key: $appname/command \n");
+         die(1);
+      }
    }
+   
    
    if($ext > 0)
    {
       $result = $appkey->SetValue("Extended", "");
+   }
+   else
+   {
+      # Delete the extended value - didn't find a DeleteValue method so must use the 'hash' notation
+      # with delim prefix to indicate it is a value
+      delete $appkey->{$delim . "Extended"};
    }
    $result = $cmdkey->SetValue("", $cmd);   
    return $result;

--- a/foldermd5.pl
+++ b/foldermd5.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# 06 May 2022 Improve installation procedure.
+# 06 May 2022 Improve installation procedure. Version info. (No constant LOG or CONSOLE)
 # 09 Feb 2022 Uses shared logging module. Can configure Windows registry with current script location
 # 26 Apr 2019 Update the console title with name of directory being processed. Handy when the
 #             output is directed to a log file, eg. when run from context menu.

--- a/testregedit.pl
+++ b/testregedit.pl
@@ -1,10 +1,11 @@
 use 5.010;  # Available since 2007, so should be safe to use this!!
 use strict;
 use warnings;
-use FindBin;           # This should find the location of this script
+use FindBin;           # This should find the directory of this script
 use lib $FindBin::Bin . '/lib'; # This indicates to look for modules in the script location
 use Data::Dumper;
 use Win32::TieRegistry ( Delimiter=>"/");
+use Win32;
 use File::Spec;
 
 my $GSCRIPTPATH = "";
@@ -36,7 +37,7 @@ if( $GPERLPATH eq "" )
 
 if( $GSCRIPTPATH eq "" )
 {
-   $GSCRIPTPATH =  File::Spec->catdir($FindBin::RealBin, $FindBin::RealScript) ;
+   $GSCRIPTPATH =  File::Spec->catdir($FindBin::Bin, $FindBin::Script) ;
    print "Perl script path: $GSCRIPTPATH\n";
 }
 
@@ -99,43 +100,54 @@ my $shellKey;
 
 }
 
-####### main part of prgram - should be a function so it canbe added to foldermd5 'as-is'
-
-# HKEY_CLASSES_ROOT\Directory\shell\FolderMD5
+sub registerfmd5
+{
 my $shellRootName = "";
 
+   # Apparently this can only be read by an Administrator. It may be that it can only be written by Admin
+   # and the default access mode is read/write. Will need to experiment with that. Anyway it looks like just
+   # running the app and creating the keys if they are not there will not work. It will need to be an option
+   # which must be used in an administrator prompt.
 
-# Apparently this can only be read by an Administrator. It may be that it can only be written by Admin
-# and the default access mode is read/write. Will need to experiment with that. Anyway it looks like just
-# running the app and creating the keys if they are not there will not work. It will need to be an option
-# which must be used in an administrator prompt.
+   # There is some scope here for iterating over a list but note that not all options are the same
+   $shellRootName = "Classes/Directory/shell/";
+   addfmd5toKey($shellRootName, "-l -p");
 
-# There is some scope here for iterating over a list but note that not all options are the same
-$shellRootName = "Classes/Directory/shell/";
-addfmd5toKey($shellRootName, "-l -p");
+   $shellRootName = "Classes/Drive/shell/";
+   addfmd5toKey($shellRootName, "-l -p");
 
-$shellRootName = "Classes/Drive/shell/";
-addfmd5toKey($shellRootName, "-l -p");
+   $shellRootName = "Classes/DVD/shell/";
+   addfmd5toKey($shellRootName, "-c -l -p");
 
-$shellRootName = "Classes/DVD/shell/";
-addfmd5toKey($shellRootName, "-c -l -p");
+   # Previously these were under 'FolderMD5 Update' but now use the same name as for Drive,Directory
+   $shellRootName = "Classes/iTunes.m4v/shell/";
+   addfmd5toKey($shellRootName, "-l -p");
 
-# Previously these were under 'FolderMD5 Update' but now use the same name as for Drive,Directory
-$shellRootName = "Classes/iTunes.m4v/shell/";
-addfmd5toKey($shellRootName, "-l -p");
+   $shellRootName = "Classes/WMP11.AssocFile.MP3/shell/";
+   addfmd5toKey($shellRootName, "-l -p");
 
-$shellRootName = "Classes/WMP11.AssocFile.MP3/shell/";
-addfmd5toKey($shellRootName, "-l -p");
+   $shellRootName = "Classes/WMP.FlacFile/shell/";
+   addfmd5toKey($shellRootName, "-l -p");
 
-$shellRootName = "Classes/WMP.FlacFile/shell/";
-addfmd5toKey($shellRootName, "-l -p");
+   $shellRootName = "Classes/WMP11.AssocFile.MP4/shell/";
+   addfmd5toKey($shellRootName, "-l -p");
 
-$shellRootName = "Classes/WMP11.AssocFile.MP4/shell/";
-addfmd5toKey($shellRootName, "-l -p");
-
-# The other type of key is for the 'Extended' context menu entry, the 'Shift-click' menu,
-# where the force recalculate item appears, ie. 'FolderMD5 Recalculate'
-# This is only added for Drive and Directory (makes no sense for DVD which is assumed to be read only)
-# This requires the '"Extended"="' value adding to the 'FolderMD5 Recalculate' key.
-addfmd5RecalctoKey("Classes/Drive/shell/", "-r -l -p");
-addfmd5RecalctoKey("Classes/Directory/shell/", "-r -l -p");
+   # The other type of key is for the 'Extended' context menu entry, the 'Shift-click' menu,
+   # where the force recalculate item appears, ie. 'FolderMD5 Recalculate'
+   # This is only added for Drive and Directory (makes no sense for DVD which is assumed to be read only)
+   # This requires the '"Extended"="' value adding to the 'FolderMD5 Recalculate' key.
+   addfmd5RecalctoKey("Classes/Drive/shell/", "-r -l -p");
+   addfmd5RecalctoKey("Classes/Directory/shell/", "-r -l -p");
+}
+####### main part of prgram - should be a function so it can be added to foldermd5 'as-is'
+if ( Win32::IsAdminUser != 0 )
+{
+   registerfmd5();
+}
+else
+{
+   # Could use Win32::RunAsAdmin (https://metacpan.org/pod/Win32%3a%3aRunAsAdmin) which
+   # restarts the script in a Admin console, which closes immediately which sort of ugly.
+   # No doubt workaround is possible but for now I'll keep it simple
+   print "The (re-)register option is only available when running as Administrator\n";
+}

--- a/testregedit.pl
+++ b/testregedit.pl
@@ -31,6 +31,12 @@ my ($shellKeyName, $scriptKeyName, $options, $extended) = @_;
 # chunky: C:\development\Perl64\bin\perl.exe "C:/Development/utils/perlutils\foldermd5.pl" -l -p "%1"
 if( $GPERLPATH eq "" )
 {
+   
+my $secure_perl_path = $Config{perlpath};
+if ($^O ne 'VMS') {
+    $secure_perl_path .= $Config{_exe}
+    unless $secure_perl_path =~ m/$Config{_exe}$/i;
+}
    $GPERLPATH = $^X;
    print "Perl executable path: $GPERLPATH\n";
 }

--- a/testregedit.pl
+++ b/testregedit.pl
@@ -5,6 +5,10 @@ use FindBin;           # This should find the location of this script
 use lib $FindBin::Bin . '/lib'; # This indicates to look for modules in the script location
 use Data::Dumper;
 use Win32::TieRegistry ( Delimiter=>"/");
+use File::Spec;
+
+my $GSCRIPTPATH = "";
+my $PERLPATH = "";
 
 
 # HKEY_CLASSES_ROOT\Directory\shell\FolderMD5
@@ -25,12 +29,25 @@ $shellRootName = "Classes/DVD/shell/";
 addfmd5toKey($shellRootName, "-c -l -p");
 
 
+
 sub addfmd5toKey
 {
 my ($shellKeyName, $options) = @_;
 # Probably makes more sense for the perl and the script  paths to be supplied
 # as they will be common for all entries
 # chunky: C:\development\Perl64\bin\perl.exe "C:/Development/utils/perlutils\foldermd5.pl" -l -p "%1"
+if( $PERLPATH eq "" )
+{
+   $PERLPATH = $^X;
+   print "Perl executable path: $PERLPATH\n";
+}
+
+if( $GSCRIPTPATH eq "" )
+{
+   $GSCRIPTPATH =  File::Spec->catdir($FindBin::RealBin, $FindBin::RealScript) ;
+   print "Perl script path: $GSCRIPTPATH\n";
+}
+
 my $perlpath = "C:\\Development\\Perl64\\perl\\bin\\perl.exe";
 my $scriptpath = "C:\\Development\\utils\\perlutils\\foldermd5.pl";
 

--- a/testregedit.pl
+++ b/testregedit.pl
@@ -8,34 +8,81 @@ use Win32::TieRegistry ( Delimiter=>"/");
 
 
 # HKEY_CLASSES_ROOT\Directory\shell\FolderMD5
-my $shellKeyName = "Classes/Directory/shell/";
-my $shellKey;
+my $shellRootName = "Classes/Directory/shell/";
+
 
 # Apparently this can only be read by an Administrator. It may be that it can only be written by Admin
 # and the default access mode is read/write. Will need to experiment with that. Anyway it looks like just
 # running the app and creating the keys if they are not there will not work. It will need to be an option
 # which must be used in an administrator promp.
-my $p = "Classes/Directory/shell/"; 
 
+addfmd5toKey($shellRootName, "-l -p");
+
+$shellRootName = "Classes/Drive/shell/";
+addfmd5toKey($shellRootName, "-l -p");
+
+$shellRootName = "Classes/DVD/shell/";
+addfmd5toKey($shellRootName, "-c -l -p");
+
+
+sub addfmd5toKey
+{
+my ($shellKeyName, $options) = @_;
+# Probably makes more sense for the perl and the script  paths to be supplied
+# as they will be common for all entries
+# chunky: C:\development\Perl64\bin\perl.exe "C:/Development/utils/perlutils\foldermd5.pl" -l -p "%1"
+my $perlpath = "C:\\Development\\Perl64\\perl\\bin\\perl.exe";
+my $scriptpath = "C:\\Development\\utils\\perlutils\\foldermd5.pl";
+
+my $shellKey;   
    $shellKey = $Registry->{$shellKeyName}; # or die "No shell keys for Directory: $!\n";
    
-   foreach my $keyval ( keys %$shellKey )
+#   foreach my $keyval ( keys %$shellKey )
+#   {
+#      if ( $shellKey->{$keyval} )
+#      {
+#         print "$keyval: " , $shellKey->{$keyval}, "\n";
+#      }
+#   }
+
+
+   # Running as normal user the FolderMD5 key cannot be read so it is created, without error.
+   # The subkeys/values are then created and read without error BUT nothing appears in the registry!
+   # For some reason DVD/shell/ is the only one which reports it cannot create the FolderMD5 key.
+   # From an admin prompt it appears to work - at least it updated the values on chunky
+   my $fmdsubKeyName="FolderMD5/";
+   my $fmdKey = $shellKey->{ $fmdsubKeyName };
+   
+   if( ! $fmdKey )
    {
-      if ( $shellKey->{$keyval} )
-      {
-         print "$keyval: " , $shellKey->{$keyval}, "\n";
-      }
+      print "Creating $fmdsubKeyName for $shellKeyName\n";
+      $shellKey->{ $fmdsubKeyName } =  {"command/" => {} } ;
    }
 
-my $fmdsubKeyName="FolderMD5/";
-my $fmd = $shellKey->{ $fmdsubKeyName };
-
-if( ! $fmd )
-{
-   print "$fmdsubKeyName not defined for $shellKeyName\n";
-    $shellKey->{ $fmdsubKeyName } =  {"command/" => {} } ;
-   my $cmdKey = $shellKey->{ $fmdsubKeyName }->{"command/"};
    
-  $cmdKey->{'/'} =  "\"E:\\Development\\Perl64\\perl\\bin\\perl.exe\" \"E:\\Development\\utils\\perlutils\\foldermd5.pl\" -l -p \"%1\"" ;
-}
 
+   # Always add/update the value as the path/options may have changed
+   $fmdKey = $shellKey->{ $fmdsubKeyName };
+   if( $fmdKey )
+   {
+      my $cmdKey = $fmdKey->{"command/"};
+      if( $cmdKey )
+      {
+         if( $options ne "" )
+         {
+            $options = " " . $options;
+         }
+         print "Updating 'command' values for  '$shellKeyName'\n";
+         $cmdKey->{'/'} =  "\"$perlpath\" \"$scriptpath\"$options \"%1\"" ;
+      }
+      else
+      {
+         print "Cannot read '$fmdsubKeyName/command' key for '$shellKeyName'\n";
+      }
+   }
+   else
+   {
+      print "Cannot create/read '$fmdsubKeyName' key for '$shellKeyName'\n";
+   }
+
+}

--- a/testregedit.pl
+++ b/testregedit.pl
@@ -1,0 +1,41 @@
+use 5.010;  # Available since 2007, so should be safe to use this!!
+use strict;
+use warnings;
+use FindBin;           # This should find the location of this script
+use lib $FindBin::Bin . '/lib'; # This indicates to look for modules in the script location
+use Data::Dumper;
+use Win32::TieRegistry ( Delimiter=>"/");
+
+
+# HKEY_CLASSES_ROOT\Directory\shell\FolderMD5
+my $shellKeyName = "Classes/Directory/shell/";
+my $shellKey;
+
+# Apparently this can only be read by an Administrator. It may be that it can only be written by Admin
+# and the default access mode is read/write. Will need to experiment with that. Anyway it looks like just
+# running the app and creating the keys if they are not there will not work. It will need to be an option
+# which must be used in an administrator promp.
+my $p = "Classes/Directory/shell/"; 
+
+   $shellKey = $Registry->{$shellKeyName}; # or die "No shell keys for Directory: $!\n";
+   
+   foreach my $keyval ( keys %$shellKey )
+   {
+      if ( $shellKey->{$keyval} )
+      {
+         print "$keyval: " , $shellKey->{$keyval}, "\n";
+      }
+   }
+
+my $fmdsubKeyName="FolderMD5/";
+my $fmd = $shellKey->{ $fmdsubKeyName };
+
+if( ! $fmd )
+{
+   print "$fmdsubKeyName not defined for $shellKeyName\n";
+    $shellKey->{ $fmdsubKeyName } =  {"command/" => {} } ;
+   my $cmdKey = $shellKey->{ $fmdsubKeyName }->{"command/"};
+   
+  $cmdKey->{'/'} =  "\"E:\\Development\\Perl64\\perl\\bin\\perl.exe\" \"E:\\Development\\utils\\perlutils\\foldermd5.pl\" -l -p \"%1\"" ;
+}
+


### PR DESCRIPTION
Apparently I added auto-reg functionality to fmd5 back in Feb 2022 and have absolutely no recollection of doing it!!! I can't even imagine what the command line option, '-w', to invoke it stood for!! I even used the much more comprehensible named methods for managing the keys rather than the obfuscated 'hash' syntax I used in testregedit.pl - since the methods are well hidden at the end after all the 'hash' shirt, I must have spent some time on it! I've refactored it a bit given the additional understanding which came from creating testregedit.pl, mainly getting rid of the deleteKeys and using CreateKey alone instead of Open and Create. Also added the check for admin privs. Changed the command option to something more meaningful, ie. '-i' for install.