### PR TITLE
fix for duplicate tvshow ids

### DIFF
--- a/eit2eps.pl
+++ b/eit2eps.pl
@@ -38,7 +38,7 @@ use XML::Simple;
 use XML::XPath;   # cpanm install XML::XPath
 use XML::Twig;    # Only used to pretty print the output XML
 use open ":std", ":encoding(UTF-8)"; # Tell Perl UTF-8 is being used.
-print "EIT2EPS v3.9 202604021037\n";
+print "EIT2EPS v3.9 202604021111\n";
 
 # Kludge to provide a command to create the folder artwork for a new program
 # the command should contain placeholders for the program name (#PROGNAME#) and the program directory (#PROGDIR#)


### PR DESCRIPTION
fix is to use '.' instead of '+' for string concatentation in createFolderNFO although this does not show as a difference. I originally committed the changes to the 'main' branch locally and tried to push main to git hub. This resulted in an error message although it appears that the change was still pushed.