### PR TITLE
win11 ignores occasional nosleep directive, try making it more often

### DIFF
--- a/eit2eps.pl
+++ b/eit2eps.pl
@@ -1004,7 +1004,7 @@ my $fh;
       #$ctx->add($data);
       #$digest = $ctx->hexdigest;
       $digest = crc32($data);
-      print "Digest for '$data': $digest\n";
+      #print "Digest for '$data': $digest\n";
    };
 
    if($@)

--- a/lib/FALC/SCUWin.pm
+++ b/lib/FALC/SCUWin.pm
@@ -87,17 +87,22 @@ my $startsecs = time();
    $sleep *= 60;
    if($totsleep>0)
    {
+      # With Windows 11 minnie keeps going to sleep even though iambusy is running
+      # with a sleep value of 2mins.
+      # So try issuing ES_SYSTEM_REQUIRED very frequently, ie. every 5 second
+      $sleep = 5;
+        
       # If a total sleep is specified make sure the "poll" interval
       # is sensible
-      if($sleep < 1)
-      {
-         $sleep = $totsleep / 10;
-         # Probably a better way to do this...
-         if($sleep < 1)
-         {
-            $sleep = 1;
-         }
-      }
+      #if($sleep < 1)
+      #{
+      #   $sleep = $totsleep / 10;
+      #   # Probably a better way to do this...
+      #   if($sleep < 1)
+      #   {
+      #      $sleep = 1;
+      #   }
+      #}
    
       $ts = time2date($startsecs + $totsleep);
       $LOG->info("iambusy: Preventing computer sleep until $ts\n");


### PR DESCRIPTION
no idea if this helps but it is what is in use on the afflicted system and I haven't noticed it being asleep when the airplay connection randomly stops working.